### PR TITLE
Replace  global `rendermime` with local one in active notebook

### DIFF
--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -96,7 +96,7 @@ function updateToggleButton(
 /**
  * A handler for debugging a widget.
  */
-export class DebuggerHandler {
+export class DebuggerHandler implements DebuggerHandler.IHandler {
   /**
    * Instantiate a new DebuggerHandler.
    *
@@ -107,6 +107,13 @@ export class DebuggerHandler {
     this._shell = options.shell;
     this._service = options.service;
   }
+
+  /**
+   * Get the active widget.
+   */
+  get activeWidget(): DebuggerHandler.SessionWidget[DebuggerHandler.SessionType] | null {
+    return this._activeWidget
+  }  
 
   /**
    * Update a debug handler for the given widget, and
@@ -173,6 +180,7 @@ export class DebuggerHandler {
     }
     connection.iopubMessage.connect(iopubMessage);
     this._iopubMessageHandlers[widget.id] = iopubMessage;
+    this._activeWidget = widget
 
     return this._update(widget, connection);
   }
@@ -391,6 +399,7 @@ export class DebuggerHandler {
   private _shell: JupyterFrontEnd.IShell;
   private _service: IDebugger;
   private _previousConnection: Session.ISessionConnection | null;
+  private _activeWidget : DebuggerHandler.SessionWidget[DebuggerHandler.SessionType] | null
   private _handlers: {
     [id: string]: DebuggerHandler.SessionHandler[DebuggerHandler.SessionType];
   } = {};
@@ -457,6 +466,41 @@ export namespace DebuggerHandler {
      * The debugger service.
      */
     service: IDebugger;
+  }
+
+  /**
+   * An interface for debugger handler.
+   */
+  export interface IHandler {
+
+    /**
+     * Get the active widget.
+     */
+    activeWidget : DebuggerHandler.SessionWidget[DebuggerHandler.SessionType] | null;
+
+    /**
+     * Update a debug handler for the given widget, and
+     * handle kernel changed events.
+     *
+     * @param widget The widget to update.
+     * @param connection The session connection.
+     */
+    update(
+      widget: DebuggerHandler.SessionWidget[DebuggerHandler.SessionType],
+      connection: Session.ISessionConnection | null
+    ): Promise<void> ;
+
+    /**
+     * Update a debug handler for the given widget, and
+     * handle connection kernel changed events.
+     *
+     * @param widget The widget to update.
+     * @param sessionContext The session context.
+     */
+    updateContext(
+      widget: DebuggerHandler.SessionWidget[DebuggerHandler.SessionType],
+      sessionContext: ISessionContext
+    ): Promise<void>
   }
 
   /**

--- a/packages/debugger/src/index.ts
+++ b/packages/debugger/src/index.ts
@@ -11,5 +11,6 @@ export {
   IDebugger,
   IDebuggerConfig,
   IDebuggerSources,
-  IDebuggerSidebar
+  IDebuggerSidebar,
+  IDebuggerHandler
 } from './tokens';

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -15,6 +15,8 @@ import { Widget } from '@lumino/widgets';
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 
+import {DebuggerHandler} from './handler'
+
 /**
  * An interface describing an application's visual debugger.
  */
@@ -222,6 +224,11 @@ export namespace IDebugger {
      */
     setTmpFileParams(params: IConfig.FileParams): void;
   }
+
+  /**
+   * An interface for debugger handler.
+   */
+  export interface IHandler extends DebuggerHandler.IHandler {}
 
   /**
    * An interface for a scope.
@@ -901,4 +908,11 @@ export const IDebuggerSources = new Token<IDebugger.ISources>(
  */
 export const IDebuggerSidebar = new Token<IDebugger.ISidebar>(
   '@jupyterlab/debugger:IDebuggerSidebar'
+);
+
+/**
+ * The debugger handler token.
+ */
+export const IDebuggerHandler = new Token<IDebugger.IHandler>(
+  '@jupyterlab/debugger:IDebuggerHandler'
 );


### PR DESCRIPTION
## Code changes

- Add `activeWidget`property to `DebuggerHandler` to get the active widget of debugger handler.
- Notebook debugging plugin now provides debugger handler token.
- `renderMimeVariable` command of detailed  variable views plugin  uses `rendermime` of active notebook instead of global one.


