### PR TITLE
Small fixes

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -718,7 +718,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     super.onSharedModelChanged(sender, change);
     globalModelDBMutex(() => {
       if (change.outputsChange) {
-        this.clearExecution();
+        this.outputs.clear();
         sender.getOutputs().forEach(output => this._outputs.add(output));
       }
     });

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -584,7 +584,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
       this._awareness.destroy();
       doc.destroy();
     }
-    if (this._undoManager) {
+    if (!this.notebook && this._undoManager) {
       this._undoManager.destroy();
     }
     Signal.clearData(this);

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -714,7 +714,6 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.IBaseCell {
-    // console.log(this.ymodel.get('id'))
     return {
       id: this.getId(),
       cell_type: this.cell_type,
@@ -944,7 +943,6 @@ export class YCodeCell
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.ICodeCell {
-    // console.log(super.toJSON())
     return {
       ...(super.toJSON() as nbformat.ICodeCell),
       outputs: this.getOutputs(),
@@ -1592,7 +1590,6 @@ export class YNotebook
       } else if (d.delete != null) {
         cellsChange.push(d);
         const oldValues = this.cells.splice(index, d.delete);
-        // console.log(JSON.stringify(oldValues, undefined, 2))
 
         this._cellsChanged.emit({
           type: 'remove',

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -880,7 +880,11 @@ export class YCodeCell
     return this.ymodel.get('execution_count') || null;
   }
   set execution_count(count: number | null) {
-    if (this.execution_count !== count) {
+    // Do not use `this.execution_count`. When initializing the
+    // cell, we need to set execution_count to `null` if we compare
+    // using `this.execution_count` it will return `null` and we will
+    // never initialize it
+    if (this.ymodel.get('execution_count') !== count) {
       this.transact(() => {
         this.ymodel.set('execution_count', count);
       });


### PR DESCRIPTION
Fixes the `execution_count` property.
Fixes the undo manager (This is probably the cause of DocRegistry test failing).
Removes some leftovers.

